### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python scopy.py"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Scopy
 
+[![Run on Repl.it](https://repl.it/badge/github/narimiran/scopy)](https://repl.it/github/narimiran/scopy)
+
 Python script for searching through your digital books and cataloguing them in an easy-to-share list of files.
 
 &nbsp;


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@joshwood/scopy-1).